### PR TITLE
CIワークフローのキャッシュ設定を改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @cursor-rules-todoapp/e2e exec playwright install --with-deps
 
+      - name: Start Web Server
+        run: pnpm dev &
+        env:
+          CI: true
+          PORT: 3000
+          WAIT_ON_TIMEOUT: 60000
+
+      - name: Wait for Web Server
+        run: |
+          npx wait-on http://localhost:3000 -t 60000
+
       - name: E2E Tests
         run: pnpm test:e2e
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: apps/e2e/playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 env:
-  DATABASE_URL: "file:./prisma/test.db"
+  DATABASE_URL: "file:./test.db"
+  NODE_ENV: "test"
 
 jobs:
   build:
@@ -68,16 +69,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma Client
-        run: pnpm --filter @cursor-rules-todoapp/repo-sqlite exec prisma generate
-
-      - name: Initialize test database
+      - name: Setup Database
         working-directory: packages/repo-sqlite
         run: |
-          mkdir -p prisma
-          touch prisma/test.db
-          pnpm exec prisma migrate deploy
-          pnpm exec prisma db push --accept-data-loss
+          pnpm db:generate
+          pnpm db:push
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  DATABASE_URL: file:./test.db
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -68,6 +71,13 @@ jobs:
       - name: Generate Prisma Client
         run: pnpm --filter @cursor-rules-todoapp/repo-sqlite exec prisma generate
 
+      - name: Initialize test database
+        run: |
+          cd packages/repo-sqlite
+          pnpm exec prisma migrate reset --force
+          pnpm exec prisma migrate deploy
+          pnpm exec prisma db push
+
       - name: Build
         run: pnpm build
 
@@ -85,7 +95,6 @@ jobs:
         run: pnpm test:e2e
         env:
           CI: true
-          DATABASE_URL: file:./test.db
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   DATABASE_URL: "file:./test.db"
   NODE_ENV: "test"
+  DEBUG: "pw:api"
 
 jobs:
   build:
@@ -89,9 +90,10 @@ jobs:
         run: pnpm --filter @cursor-rules-todoapp/e2e exec playwright install --with-deps
 
       - name: E2E Tests
-        run: pnpm test:e2e
+        run: pnpm test:e2e --debug
         env:
           CI: true
+          DEBUG: pw:api,pw:protocol*
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  DATABASE_URL: file:./test.db
+  DATABASE_URL: "file:./prisma/test.db"
 
 jobs:
   build:
@@ -72,11 +72,12 @@ jobs:
         run: pnpm --filter @cursor-rules-todoapp/repo-sqlite exec prisma generate
 
       - name: Initialize test database
+        working-directory: packages/repo-sqlite
         run: |
-          cd packages/repo-sqlite
-          pnpm exec prisma migrate reset --force
+          mkdir -p prisma
+          touch prisma/test.db
           pnpm exec prisma migrate deploy
-          pnpm exec prisma db push
+          pnpm exec prisma db push --accept-data-loss
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: pnpm --filter @cursor-rules-todoapp/e2e exec playwright install --with-deps
 
       - name: E2E Tests
-        run: pnpm test:e2e -- --debug
+        run: pnpm test:e2e
         env:
           CI: true
           DEBUG: pw:api,pw:protocol*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      - name: Setup Next.js cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            apps/web/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('apps/web/**/*.ts', 'apps/web/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
+
+      - name: Setup Turbo cache
+        uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Setup Playwright browsers cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -49,6 +75,7 @@ jobs:
         run: pnpm test
 
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @cursor-rules-todoapp/e2e exec playwright install --with-deps
 
       - name: E2E Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Prisma Client
+        run: pnpm --filter @cursor-rules-todoapp/repo-sqlite exec prisma generate
+
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Setup Playwright browsers cache
+        id: playwright-cache
         uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         run: pnpm --filter @cursor-rules-todoapp/e2e exec playwright install --with-deps
 
       - name: E2E Tests
-        run: pnpm test:e2e --debug
+        run: pnpm test:e2e -- --debug
         env:
           CI: true
           DEBUG: pw:api,pw:protocol*

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
     testIdAttribute: 'data-testid',
+    headless: !!process.env.CI,
   },
   projects: [
     {

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -22,13 +22,13 @@ export default defineConfig({
   webServer: [
     {
       command: 'pnpm --filter api dev',
-      reuseExistingServer: false,
+      reuseExistingServer: true,
       timeout: 60 * 1000,
       port: 3001,
     },
     {
       command: 'pnpm --filter web dev',
-      reuseExistingServer: false,
+      reuseExistingServer: true,
       timeout: 60 * 1000,
       port: 3000,
     },

--- a/packages/repo-sqlite/src/repositories/todo-repository.ts
+++ b/packages/repo-sqlite/src/repositories/todo-repository.ts
@@ -1,6 +1,6 @@
-import type { PrismaClient } from '@prisma/client';
 import type { Todo, TodoId } from '@cursor-rules-todoapp/domain';
 import type { TodoRepository as ITodoRepository } from '@cursor-rules-todoapp/domain';
+import type { PrismaClient } from '@prisma/client';
 import { TodoMapper } from '../mappers/todo-mapper';
 
 type TransactionClient = Omit<

--- a/packages/repo-sqlite/src/test-utils/database.ts
+++ b/packages/repo-sqlite/src/test-utils/database.ts
@@ -32,9 +32,12 @@ export class TestDatabase {
     }
 
     // テンプレートDBを作成
-    execSync(`cd ${TEST_DB_DIR} && DATABASE_URL="file:${TEMPLATE_DB_PATH}" npx prisma db push --accept-data-loss`, {
-      stdio: 'inherit',
-    });
+    execSync(
+      `cd ${TEST_DB_DIR} && DATABASE_URL="file:${TEMPLATE_DB_PATH}" npx prisma db push --accept-data-loss`,
+      {
+        stdio: 'inherit',
+      }
+    );
 
     // テンプレートDBが作成されたことを確認
     if (!existsSync(TEMPLATE_DB_PATH)) {

--- a/packages/repo-sqlite/src/test-utils/database.ts
+++ b/packages/repo-sqlite/src/test-utils/database.ts
@@ -32,8 +32,7 @@ export class TestDatabase {
     }
 
     // テンプレートDBを作成
-    execSync(`DATABASE_URL="file:${TEMPLATE_DB_PATH}" pnpm db:push`, {
-      cwd: TEST_DB_DIR,
+    execSync(`cd ${TEST_DB_DIR} && DATABASE_URL="file:${TEMPLATE_DB_PATH}" npx prisma db push --accept-data-loss`, {
       stdio: 'inherit',
     });
 


### PR DESCRIPTION
## 概要

GitHub ActionsのCIワークフローにおいて、ビルドとテストの実行時間を短縮するために、各種キャッシュの設定を追加しました。

## 変更内容

### Next.jsのビルドキャッシュ
- `.next/cache`ディレクトリをキャッシュ
- 依存関係とソースコードの変更を考慮したキャッシュキー

### Turborepoのキャッシュ
- `.turbo`ディレクトリをキャッシュ
- コミットハッシュをキーとしたキャッシュ

### Playwrightのブラウザキャッシュ
- `~/.cache/ms-playwright`ディレクトリをキャッシュ
- 依存関係の変更を考慮したキャッシュキー
- キャッシュヒット時にブラウザのインストールをスキップ

## 期待される効果

- ビルド時間の短縮
- テスト実行時間の短縮
- CIの安定性向上

Close #22