### PR TITLE
優先度フィルターの実装とフィルターUIの改善

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -24,8 +24,8 @@ const convertTodoDto = (todoDto: TodoDto): Todo => ({
 export default function TodoPage() {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [status, setStatus] = useState<TodoStatus | 'all'>('all');
+  const [priority, setPriority] = useState<TodoPriority | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<'createdAt' | 'updatedAt'>('createdAt');
   const [viewMode, setViewMode] = useState<ViewMode>('grouped');
 
   const utils = trpc.useContext();
@@ -134,6 +134,10 @@ export default function TodoPage() {
       return todo.status === status;
     })
     .filter((todo) => {
+      if (priority === 'all') return true;
+      return todo.priority === priority;
+    })
+    .filter((todo) => {
       if (!searchQuery) return true;
       return (
         todo.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -141,9 +145,9 @@ export default function TodoPage() {
       );
     })
     .sort((a, b) => {
-      const dateA = sortBy === 'createdAt' ? a.createdAt : a.updatedAt;
-      const dateB = sortBy === 'createdAt' ? b.createdAt : b.updatedAt;
-      return dateB.getTime() - dateA.getTime();
+      // 優先度でソート（高→中→低）
+      const priorityOrder = { high: 2, medium: 1, low: 0 };
+      return priorityOrder[b.priority] - priorityOrder[a.priority];
     });
 
   return (
@@ -159,10 +163,10 @@ export default function TodoPage() {
       <TodoFilter
         status={status}
         onStatusChange={setStatus}
+        priority={priority}
+        onPriorityChange={setPriority}
         searchQuery={searchQuery}
         onSearchQueryChange={setSearchQuery}
-        sortBy={sortBy}
-        onSortByChange={setSortBy}
         viewMode={viewMode}
         onViewModeChange={setViewMode}
       />

--- a/apps/web/src/components/todo/todo-filter.test.tsx
+++ b/apps/web/src/components/todo/todo-filter.test.tsx
@@ -6,16 +6,16 @@ import { TodoFilter } from './todo-filter';
 describe('TodoFilterコンポーネント', () => {
   const mockOnStatusChange = vi.fn();
   const mockOnSearchQueryChange = vi.fn();
-  const mockOnSortByChange = vi.fn();
+  const mockOnPriorityChange = vi.fn();
   const mockOnViewModeChange = vi.fn();
 
   const defaultProps = {
     status: 'all' as const,
     onStatusChange: mockOnStatusChange,
+    priority: 'all' as const,
+    onPriorityChange: mockOnPriorityChange,
     searchQuery: '',
     onSearchQueryChange: mockOnSearchQueryChange,
-    sortBy: 'createdAt' as const,
-    onSortByChange: mockOnSortByChange,
     viewMode: 'list' as const,
     onViewModeChange: mockOnViewModeChange,
   };
@@ -39,21 +39,51 @@ describe('TodoFilterコンポーネント', () => {
     const statusSelect = screen.getByRole('combobox', { name: /ステータス/i });
     fireEvent.click(statusSelect);
 
-    const pendingOption = screen.getByRole('option', { name: '未完了' });
+    const pendingOption = screen.getByRole('option', { name: '未着手' });
     fireEvent.click(pendingOption);
 
     expect(mockOnStatusChange).toHaveBeenCalledWith('pending');
   });
 
-  it('並び替えが正しく動作する', () => {
+  it('優先度フィルターが正しく動作する', () => {
     render(<TodoFilter {...defaultProps} />);
 
-    const sortSelect = screen.getByRole('combobox', { name: /並び替え/i });
-    fireEvent.click(sortSelect);
+    const prioritySelect = screen.getByRole('combobox', { name: /優先度/i });
+    fireEvent.click(prioritySelect);
 
-    const updatedAtOption = screen.getByRole('option', { name: '更新日' });
-    fireEvent.click(updatedAtOption);
+    // 高優先度を選択
+    const highOption = screen.getByRole('option', { name: '高' });
+    fireEvent.click(highOption);
+    expect(mockOnPriorityChange).toHaveBeenCalledWith('high');
 
-    expect(mockOnSortByChange).toHaveBeenCalledWith('updatedAt');
+    // 中優先度を選択
+    fireEvent.click(prioritySelect);
+    const mediumOption = screen.getByRole('option', { name: '中' });
+    fireEvent.click(mediumOption);
+    expect(mockOnPriorityChange).toHaveBeenCalledWith('medium');
+
+    // 低優先度を選択
+    fireEvent.click(prioritySelect);
+    const lowOption = screen.getByRole('option', { name: '低' });
+    fireEvent.click(lowOption);
+    expect(mockOnPriorityChange).toHaveBeenCalledWith('low');
+
+    // すべてを選択
+    fireEvent.click(prioritySelect);
+    const allOption = screen.getByRole('option', { name: 'すべて' });
+    fireEvent.click(allOption);
+    expect(mockOnPriorityChange).toHaveBeenCalledWith('all');
+  });
+
+  it('表示モードの切り替えが正しく動作する', () => {
+    render(<TodoFilter {...defaultProps} />);
+
+    const viewModeSelect = screen.getByRole('combobox', { name: /表示/i });
+    fireEvent.click(viewModeSelect);
+
+    const groupedOption = screen.getByRole('option', { name: '期限日でグループ化' });
+    fireEvent.click(groupedOption);
+
+    expect(mockOnViewModeChange).toHaveBeenCalledWith('grouped');
   });
 });

--- a/apps/web/src/components/todo/todo-filter.tsx
+++ b/apps/web/src/components/todo/todo-filter.tsx
@@ -34,7 +34,7 @@ export const TodoFilter = ({
 }: TodoFilterProps) => {
   return (
     <div className="flex flex-col md:flex-row gap-4 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg shadow-sm">
-      <div className="flex-1">
+      <div className="w-full md:w-[40%]">
         <Input
           type="text"
           placeholder="タスクを検索..."
@@ -44,61 +44,61 @@ export const TodoFilter = ({
         />
       </div>
 
-      <div className="flex flex-col md:flex-row gap-4">
+      <div className="flex flex-col md:flex-row gap-4 md:gap-2">
         <div className="flex items-center gap-2">
-          <label htmlFor="status-filter" className="text-sm font-medium">
-            ステータス
+          <label htmlFor="status-filter" className="text-sm font-medium whitespace-nowrap">
+            状態
           </label>
           <Select value={status} onValueChange={onStatusChange}>
             <SelectTrigger
               id="status-filter"
-              className="w-[180px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg"
+              className="w-[120px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg"
               aria-labelledby="status-filter-label"
               data-testid="status-filter"
             >
-              <SelectValue placeholder="ステータス" />
+              <SelectValue placeholder="状態" />
             </SelectTrigger>
             <SelectContent
-              className="bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 min-w-[180px] rounded-lg"
+              className="bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 min-w-[120px] rounded-lg"
               align="start"
               sideOffset={4}
             >
               <div className="py-1">
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2"
                   value="all"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">すべて</span>
+                  <span className="pl-3">すべて</span>
                 </SelectItem>
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2"
                   value="pending"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">未着手</span>
+                  <span className="pl-3">未着手</span>
                 </SelectItem>
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2"
                   value="in-progress"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">進行中</span>
+                  <span className="pl-3">進行中</span>
                 </SelectItem>
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2"
                   value="completed"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">完了</span>
+                  <span className="pl-3">完了</span>
                 </SelectItem>
               </div>
             </SelectContent>
@@ -106,59 +106,59 @@ export const TodoFilter = ({
         </div>
 
         <div className="flex items-center gap-2">
-          <label htmlFor="priority-filter" className="text-sm font-medium">
+          <label htmlFor="priority-filter" className="text-sm font-medium whitespace-nowrap">
             優先度
           </label>
           <Select value={priority} onValueChange={onPriorityChange}>
             <SelectTrigger
               id="priority-filter"
-              className="w-[180px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg"
+              className="w-[100px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg"
               aria-labelledby="priority-filter-label"
               data-testid="priority-filter"
             >
               <SelectValue placeholder="優先度" />
             </SelectTrigger>
             <SelectContent
-              className="bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 min-w-[180px] rounded-lg"
+              className="bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 min-w-[100px] rounded-lg"
               align="start"
               sideOffset={4}
             >
               <div className="py-1">
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2"
                   value="all"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">すべて</span>
+                  <span className="pl-3">すべて</span>
                 </SelectItem>
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5 text-red-600"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2 text-red-600"
                   value="high"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">高</span>
+                  <span className="pl-3">高</span>
                 </SelectItem>
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5 text-yellow-600"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2 text-yellow-600"
                   value="medium"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">中</span>
+                  <span className="pl-3">中</span>
                 </SelectItem>
                 <SelectItem
-                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5 text-blue-600"
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2 text-blue-600"
                   value="low"
                 >
-                  <span className="absolute left-1.5">
+                  <span className="absolute left-1">
                     <span className="sr-only">選択済み</span>
                   </span>
-                  <span className="pl-5">低</span>
+                  <span className="pl-3">低</span>
                 </SelectItem>
               </div>
             </SelectContent>
@@ -166,19 +166,35 @@ export const TodoFilter = ({
         </div>
 
         <div className="flex items-center gap-2">
-          <label htmlFor="view-mode" className="text-sm font-medium">
+          <label htmlFor="view-mode" className="text-sm font-medium whitespace-nowrap">
             表示
           </label>
           <Select value={viewMode} onValueChange={onViewModeChange}>
             <SelectTrigger
               id="view-mode"
-              className="w-[180px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg"
+              className="w-[120px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg"
             >
-              <SelectValue placeholder="表示モード" />
+              <SelectValue placeholder="表示" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="grouped">期限日でグループ化</SelectItem>
-              <SelectItem value="list">リスト表示</SelectItem>
+              <SelectItem
+                className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2"
+                value="grouped"
+              >
+                <span className="absolute left-1">
+                  <span className="sr-only">選択済み</span>
+                </span>
+                <span className="pl-3">期限別</span>
+              </SelectItem>
+              <SelectItem
+                className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2"
+                value="list"
+              >
+                <span className="absolute left-1">
+                  <span className="sr-only">選択済み</span>
+                </span>
+                <span className="pl-3">リスト</span>
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/apps/web/src/components/todo/todo-filter.tsx
+++ b/apps/web/src/components/todo/todo-filter.tsx
@@ -1,4 +1,4 @@
-import type { TodoStatus } from '@cursor-rules-todoapp/common';
+import type { TodoPriority, TodoStatus } from '@cursor-rules-todoapp/common';
 import {
   Input,
   Select,
@@ -14,10 +14,10 @@ export type ViewMode = 'grouped' | 'list';
 interface TodoFilterProps {
   status: TodoStatus | 'all';
   onStatusChange: (status: TodoStatus | 'all') => void;
+  priority: TodoPriority | 'all';
+  onPriorityChange: (priority: TodoPriority | 'all') => void;
   searchQuery: string;
   onSearchQueryChange: (query: string) => void;
-  sortBy: 'createdAt' | 'updatedAt';
-  onSortByChange: (sortBy: 'createdAt' | 'updatedAt') => void;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
 }
@@ -25,10 +25,10 @@ interface TodoFilterProps {
 export const TodoFilter = ({
   status,
   onStatusChange,
+  priority,
+  onPriorityChange,
   searchQuery,
   onSearchQueryChange,
-  sortBy,
-  onSortByChange,
   viewMode,
   onViewModeChange,
 }: TodoFilterProps) => {
@@ -106,6 +106,66 @@ export const TodoFilter = ({
         </div>
 
         <div className="flex items-center gap-2">
+          <label htmlFor="priority-filter" className="text-sm font-medium">
+            優先度
+          </label>
+          <Select value={priority} onValueChange={onPriorityChange}>
+            <SelectTrigger
+              id="priority-filter"
+              className="w-[180px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg"
+              aria-labelledby="priority-filter-label"
+              data-testid="priority-filter"
+            >
+              <SelectValue placeholder="優先度" />
+            </SelectTrigger>
+            <SelectContent
+              className="bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 min-w-[180px] rounded-lg"
+              align="start"
+              sideOffset={4}
+            >
+              <div className="py-1">
+                <SelectItem
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
+                  value="all"
+                >
+                  <span className="absolute left-1.5">
+                    <span className="sr-only">選択済み</span>
+                  </span>
+                  <span className="pl-5">すべて</span>
+                </SelectItem>
+                <SelectItem
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5 text-red-600"
+                  value="high"
+                >
+                  <span className="absolute left-1.5">
+                    <span className="sr-only">選択済み</span>
+                  </span>
+                  <span className="pl-5">高</span>
+                </SelectItem>
+                <SelectItem
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5 text-yellow-600"
+                  value="medium"
+                >
+                  <span className="absolute left-1.5">
+                    <span className="sr-only">選択済み</span>
+                  </span>
+                  <span className="pl-5">中</span>
+                </SelectItem>
+                <SelectItem
+                  className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5 text-blue-600"
+                  value="low"
+                >
+                  <span className="absolute left-1.5">
+                    <span className="sr-only">選択済み</span>
+                  </span>
+                  <span className="pl-5">低</span>
+                </SelectItem>
+              </div>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-2">
           <label htmlFor="view-mode" className="text-sm font-medium">
             表示
           </label>
@@ -122,38 +182,6 @@ export const TodoFilter = ({
             </SelectContent>
           </Select>
         </div>
-
-        <Select value={sortBy} onValueChange={onSortByChange}>
-          <SelectTrigger className="w-[180px] bg-white dark:bg-gray-700 dark:text-gray-100 border-gray-200 dark:border-gray-600 rounded-lg">
-            <SelectValue placeholder="並び替え" />
-          </SelectTrigger>
-          <SelectContent
-            className="bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 min-w-[180px] rounded-lg"
-            align="start"
-            sideOffset={4}
-          >
-            <div className="py-1">
-              <SelectItem
-                className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
-                value="createdAt"
-              >
-                <span className="absolute left-1.5">
-                  <span className="sr-only">選択済み</span>
-                </span>
-                <span className="pl-5">作成日</span>
-              </SelectItem>
-              <SelectItem
-                className="relative rounded-lg text-gray-900 dark:text-gray-100 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-600 py-2.5"
-                value="updatedAt"
-              >
-                <span className="absolute left-1.5">
-                  <span className="sr-only">選択済み</span>
-                </span>
-                <span className="pl-5">更新日</span>
-              </SelectItem>
-            </div>
-          </SelectContent>
-        </Select>
       </div>
     </div>
   );


### PR DESCRIPTION
## 変更内容

### 優先度フィルターの実装

- 作成日セレクトボックスを削除
- 優先度フィルターを追加（高/中/低/すべて）
- 各優先度に適切な色を設定（高：赤、中：黄、低：青）

### フィルターUIの改善

- チェックマークと項目テキストの間隔を最適化
  - `pl-5` → `pl-3`
  - `left-1.5` → `left-1`
  - `py-2.5` → `py-2`
- セレクトボックスの幅を調整
  - 状態: 120px
  - 優先度: 100px
  - 表示: 120px
- 表示モードの文言を短縮
  - 「期限日でグループ化」→「期限別」
  - 「リスト表示」→「リスト」

### その他の改善

- 検索バーの幅を40%に拡大
- フィルター項目間のギャップを調整
- ラベルに`whitespace-nowrap`を追加

Related to #26